### PR TITLE
Adds a section specific to a11y ui components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,9 +374,20 @@ Design System - [A comprehensive guide to design systems](https://www.invisionap
 -   [Vaadin components](https://github.com/vaadin/vaadin) [![Repo Star](https://img.shields.io/github/stars/vaadin/vaadin.svg?label=&style=social)](https://github.com/vaadin/vaadin) - Evolving set of high-quality web components for building business web applications
 -   [Wired Elements](https://github.com/wiredjs/wired-elements) [![Repo Star](https://img.shields.io/github/stars/wiredjs/wired-elements.svg?label=&style=social)](https://github.com/wiredjs/wired-elements) - Set of common UI elements with a hand-drawn, sketchy look.
 
+
 ### Related community list
 
 -   [Web Components the Right Way](https://github.com/mateusortiz/webcomponents-the-right-way) - A curated list of awesome Web Components resources.
+
+---
+
+## A11y Components
+
+-   [a11y-dialog](https://github.com/KittyGiraudel/a11y-dialog) - A very lightweight and flexible accessible modal dialog script.
+-   [a11y-tabs](https://github.com/agnosticui/a11y-tabs) -  A lightweight (<1Kb) JavaScript package to facilitate a11y-compliant tabbed interfaces.
+-   [a11y-menu](https://aberkow.github.io/a11y-menu/) — This project aims to create a re-useable and accessible main navigation module.
+-   [Scott Ohara's a11y components](https://github.com/scottaohara/accessible_components) — Listing of accessible components & patterns.
+-   [Deque Cauldron](https://pattern-library.dequelabs.com/) — A fullyaccessibleHTML, CSS, and Javascript front-end framework for creating web and mobile applications.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,6 @@ Design System - [A comprehensive guide to design systems](https://www.invisionap
 -   [Vaadin components](https://github.com/vaadin/vaadin) [![Repo Star](https://img.shields.io/github/stars/vaadin/vaadin.svg?label=&style=social)](https://github.com/vaadin/vaadin) - Evolving set of high-quality web components for building business web applications
 -   [Wired Elements](https://github.com/wiredjs/wired-elements) [![Repo Star](https://img.shields.io/github/stars/wiredjs/wired-elements.svg?label=&style=social)](https://github.com/wiredjs/wired-elements) - Set of common UI elements with a hand-drawn, sketchy look.
 
-
 ### Related community list
 
 -   [Web Components the Right Way](https://github.com/mateusortiz/webcomponents-the-right-way) - A curated list of awesome Web Components resources.

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ Design System - [A comprehensive guide to design systems](https://www.invisionap
 
 ## A11y Components
 
+-   [a11y-contrast](https://github.com/darekkay/a11y-contrast) — A CLI utility to calculate/verify accessible magic numbers for a color palette.
 -   [a11y-dialog](https://github.com/KittyGiraudel/a11y-dialog) - A very lightweight and flexible accessible modal dialog script.
 -   [a11y-tabs](https://github.com/agnosticui/a11y-tabs) -  A lightweight (<1Kb) JavaScript package to facilitate a11y-compliant tabbed interfaces.
 -   [a11y-menu](https://aberkow.github.io/a11y-menu/) — This project aims to create a re-useable and accessible main navigation module.


### PR DESCRIPTION
As someone who is always skeptical of the a11y implementation across an entire UI component library, I find it very useful to cross reference these implementations against more focused component implementations that are tested specifically for a11y. As such I've added the `A11y Components` section.

- Added `a11y-dialog` under section `A11y Components`
- Added `a11y-tabs` under section `A11y Components`
- Added `a11y-menu` under section `A11y Components`
- Added `Scott Ohara's a11y components` under section `A11y Components`
- Added `Deque Cauldron` under section `A11y Components`

Also, I have an experimental framework called [AgnosticUI](https://github.com/AgnosticUI/agnosticui/) which, when done, will be a full-fledged component library that supports React, Vue, Angular, and Svelte. I've used `a11y-dialog` and my own `a11y-tab` as npm packages to support Tabs and Modals aka Dialogs.