### PR TITLE
Add react-datatable (paid / special-use)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Design System - [A comprehensive guide to design systems](https://www.invisionap
 -   [Styled Icons](https://styled-icons.js.org/) [![Repo Star](https://img.shields.io/github/stars/jacobwgillespie/styled-icons.svg?label=&style=social)](https://github.com/jacobwgillespie/styled-icons) - Font Awesome, Feather, Material Design, and Octicons icon packs as Styled Components
 -   `[Paid]` [ag-grid](https://www.ag-grid.com/) - Cross platform components for Grid/Tables
 -   `[Paid]` [Get Data Den](https://getdataden.com/) - Plugin that extends your projects functionality with a table component
+-   `[Paid]` [react-datatable](https://react-datatable.com/docs?utm_source=github&utm_medium=repository&utm_campaign=3rdcom265) - Source-licensed datatable kit on TanStack Table with Radix-style primitives and Tailwind; filters, grouping, views, virtualization, and client or server loading modes.
 
 ### Tools
 


### PR DESCRIPTION
Adds a `[Paid]` **react-datatable** row under **Special use case libraries** with [documentation](https://react-datatable.com/docs?utm_source=github&utm_medium=pr&utm_campaign=3rdcom265) as the link (no public GitHub repo).